### PR TITLE
Depending on refinerycms-pages >= 0.9.9.1

### DIFF
--- a/refinerycms-snippets.gemspec
+++ b/refinerycms-snippets.gemspec
@@ -9,4 +9,6 @@ Gem::Specification.new do |s|
   s.email             = %q{nospam.keram@gmail.com}
   s.require_paths     = %w(lib)
   s.files             = Dir['lib/**/*', 'config/**/*', 'app/**/*', 'db/**/*']
+
+  s.add_dependency    'refinerycms-pages', '>= 0.9.9.1'
 end


### PR DESCRIPTION
Depending on refinerycms-pages >= 0.9.9.1 seeing as this engine relates directly to pages.
