### PR TITLE
added dynamic_snippets

### DIFF
--- a/lib/extensions/application_helper_extensions.rb
+++ b/lib/extensions/application_helper_extensions.rb
@@ -21,7 +21,7 @@ module Extensions
           if part
             content = ""
             content += part.snippets.before.map{|snippet| render_snippet(snippet)}.join
-            content += part.body if part.try(:body).present?
+            content += part.body if part.body.present? and !yield_body.present?
             content += yield_body if yield_body.present?
             content += part.snippets.after.map{|snippet| render_snippet(snippet)}.join
           end

--- a/lib/extensions/application_helper_extensions.rb
+++ b/lib/extensions/application_helper_extensions.rb
@@ -1,5 +1,5 @@
 module Extensions
-  module PagesHelper
+  module ApplicationHelper
 
     def self.included(base)
       base.class_eval do
@@ -12,7 +12,7 @@ module Extensions
         #
         # Will return the body page part of the first page wrap with its
         # attached snippets.
-        def content_of(page, part_title)
+        def content_of(page, part_title, yield_body=nil)
           part = page.parts.detect do |part|
             part.title.present? and #protecting against the problem that occurs when have nil title
             title(part.title) == part_title
@@ -21,8 +21,8 @@ module Extensions
           if part
             content = ""
             content += part.snippets.before.map{|snippet| render_snippet(snippet)}.join
-            part_body = part.try(:body)
-            content += part_body unless part_body.nil?
+            content += part.body if part.try(:body).present?
+            content += yield_body if yield_body.present?
             content += part.snippets.after.map{|snippet| render_snippet(snippet)}.join
           end
         end

--- a/lib/refinerycms-snippets.rb
+++ b/lib/refinerycms-snippets.rb
@@ -6,7 +6,7 @@ module Refinery
 
       config.before_initialize do
         require 'extensions/page_extensions'
-        require 'extensions/pages_helper_extensions'
+        require 'extensions/application_helper_extensions'
       end
 
       initializer "static assets" do |app|
@@ -19,7 +19,7 @@ module Refinery
           has_many :snippets, :through => :snippet_page_parts, :order => 'position ASC'
         end
         Page.send :include, Extensions::Page
-        PagesHelper.send :include, Extensions::PagesHelper
+        ApplicationHelper.send :include, Extensions::ApplicationHelper
       end
 
       config.after_initialize do

--- a/readme.md
+++ b/readme.md
@@ -15,13 +15,13 @@ Snippets allows you to relate one or more html blocks to any page in Refinery. T
 * Save and Continue button -- done
 * Attaching snippet to page part directly through administration, without overriding view template -- done
 * Documentation
-* Tests 
+* Tests
 
 ### to 2.0
 * custom attributes for snippet (id, classes etc)
 * support for dynamic snippets (erb templates, forms etc)
-* improve UI 
-* inheritance and clone 
+* improve UI
+* inheritance and clone
 
 ## Install
 
@@ -38,8 +38,9 @@ Next run
 ## Usage
 
 * Create Snippet on /refinery/snippets
-* Now you can attach snippet to page when you click Edit this page on `/refinery/pages`. In the Snippets tab you can select the part to which you want to attach the block and add it after and/or before the html body of the part.  
-* Next you can use content_of(@page, :part) to print the body of the part and the snippets attached to it in the pages views.
+* Now you can attach snippet to page when you click Edit this page on `/refinery/pages`. In the Snippets tab you can select the part to which you want to attach the block and add it after and/or before the html body of the part.
+* Next you can use content_of(@page, :part) or to print the body of the part and the snippets attached to it in the pages views.
+* You can also use content_of(@page, :part, yield(:part)) for it to work with other engines such as blog and news
 * You have some other interesting methods to work with snippets:
   * page.snippets: returns all the snippets attached to all the parts of page.
   * part.after: returns all the snippets attached after the html body of part.

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -23,17 +23,17 @@ describe ApplicationHelper do
   end
 
   it "should return template if snippet template exists" do
-    should_receive(:render).with("shared/before_title").and_return('TEMPLATE')
+    should_receive(:render).with({:partial=>"snippets/before_title"}).and_return('TEMPLATE')
     render_snippet(@snippet_before).should == 'TEMPLATE'
   end
 
   it "should return body if snippet template doesn't exist" do
-    should_receive(:render).with("shared/before_title").and_raise(ActionView::MissingTemplate)
+    should_receive(:render).with({:partial=>"snippets/before_title"}).and_raise(ActionView::MissingTemplate)
     render_snippet(@snippet_before).should == 'BEFORE BODY'
   end
 
   it "should return nil if snippet body and template don't exist" do
-    @before_snippet.update_attribute(:body, nil)
+    @snippet_before.update_attribute(:body, nil)
     should_receive(:render).with("shared/before_title").and_raise(ActionView::MissingTemplate)
     render_snippet(@snippet_before).should be_nil
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ApplcationHelper do
+describe ApplicationHelper do
 
   before(:each) do
     @page = Page.create!(:title => 'Page title')

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -28,13 +28,13 @@ describe ApplicationHelper do
   end
 
   it "should return body if snippet template doesn't exist" do
-    should_receive(:render).with({:partial=>"snippets/before_title"}).and_raise(ActionView::MissingTemplate)
+    should_receive(:render).with({:partial=>"snippets/before_title"}).and_raise(ActionView::MissingTemplate.new([], nil, nil, nil))
     render_snippet(@snippet_before).should == 'BEFORE BODY'
   end
 
   it "should return nil if snippet body and template don't exist" do
     @snippet_before.update_attribute(:body, nil)
-    should_receive(:render).with("shared/before_title").and_raise(ActionView::MissingTemplate)
+    should_receive(:render).with({:partial=>"snippets/before_title"}).and_raise(ActionView::MissingTemplate.new([], nil, nil, nil))
     render_snippet(@snippet_before).should be_nil
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe PagesHelper do
+describe ApplcationHelper do
 
   before(:each) do
     @page = Page.create!(:title => 'Page title')

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -22,4 +22,24 @@ describe PagesHelper do
     Proc.new {content_of(@page, :part)}.should_not raise_exception
   end
 
+  it "should return template if snippet template exists" do
+    should_receive(:render).with("shared/before_title").and_return('TEMPLATE')
+    render_snippet(@snippet_before).should == 'TEMPLATE'
+  end
+
+  it "should return body if snippet template doesn't exist" do
+    should_receive(:render).with("shared/before_title").and_raise(ActionView::MissingTemplate)
+    render_snippet(@snippet_before).should == 'BEFORE BODY'
+  end
+
+  it "should return nil if snippet body and template don't exist" do
+    @before_snippet.update_attribute(:body, nil)
+    should_receive(:render).with("shared/before_title").and_raise(ActionView::MissingTemplate)
+    render_snippet(@snippet_before).should be_nil
+  end
+
+  it 'should return title' do
+    title(@part.title).should == :part
+  end
+
 end


### PR DESCRIPTION
There is already a pull request for this issue from @rochgs, but I just thought you may be interested in how I did it.  Also updated content_of method to allow body_content_left and body_content_right.

use content_of(@page, :part, yield(:part)) when you need it to work with other engines such as blog
